### PR TITLE
Fixing incompatibility with the easy-fancybox plugin

### DIFF
--- a/public/ShashinHeadTags.php
+++ b/public/ShashinHeadTags.php
@@ -27,6 +27,7 @@ class Public_ShashinHeadTags {
             'imageDisplayer' => $this->settings->imageDisplay,
             'thumbnailDisplay' => $this->settings->thumbnailDisplay,
         );
+	    $shashinJSdependencies = array( 'jquery', 'jquery-imagesloaded', 'jquery-trunk8' );
 
         if ($this->settings->imageDisplay == 'prettyphoto') {
             $shashinJsParams['prettyPhotoTheme'] = $this->settings->prettyPhotoTheme;
@@ -75,11 +76,12 @@ class Public_ShashinHeadTags {
                     '1.3.4'
                 );
                 $this->functionsFacade->enqueueScript(
-                    'fancybox',
+                    'jquery-fancybox',
                     $this->baseUrl . 'fancybox/jquery.fancybox.js',
                     array('jquery'),
                     '1.3.4'
                 );
+                $shashinJSdependencies[] = 'jquery-fancybox';
             }
         }
 
@@ -102,7 +104,7 @@ class Public_ShashinHeadTags {
         $this->functionsFacade->enqueueScript(
             'shashinJs',
             $this->baseUrl . 'shashin.js',
-            array('jquery', 'jquery-imagesloaded', 'jquery-trunk8'),
+            $shashinJSdependencies,
             $this->version,
             true
         );


### PR DESCRIPTION
In the latest versions of Shashin and easy-fancybox there is an incompatibility regarding loading the fancybox javascript:
Shashin enqueues the fancybox.js under the handle 'fancybox' and easy-fancybox enqueues it under the name 'jquery-fancybox'. Additionally easy-fancybox dequeues every other fancybox dependency. That alone isn't a problem becuase both javascript files are being loaded but the shashin.js is loaded before easy-fancybox's fancybox.js and therefore shashin.js fails to initialize fancybox, aborts its execution and breaks the whole gallery.

This PR fixes this issue by renaming Shashin's handle to 'jquery-fancybox' and making the dependency on fancybox explicit so that Wordpress can resolve it correctly.
